### PR TITLE
jsonschema 4.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,20 +36,10 @@ test:
     - jsonschema
   requires:
     - pip
-    # For testing downstream package cubes
-    - setuptools
   commands:
     - python -m pip check
     - jsonschema --version
     - jsonschema --help
-  downstreams:
-    - airflow
-    - cfn-lint
-    - cubes
-    - jupyterlab_server
-    - jupyter_telemetry
-    - nbformat
-    - spyder
 
 about:
   home: https://github.com/Julian/jsonschema

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.2.0" %}
+{% set version = "4.4.0" %}
 
 package:
   name: jsonschema
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/j/jsonschema/jsonschema-{{ version }}.tar.gz
-  sha256: c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a
+  sha256: 636694eb41b3535ed608fe04129f26542b59ed99808b4f688aa32dcf55317a83
 
 build:
   number: 2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,8 @@ test:
     - jsonschema
   requires:
     - pip
+    # For testing downstream package cubes
+    - setuptools
   commands:
     - python -m pip check
     - jsonschema --version

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,47 +9,54 @@ source:
   sha256: 636694eb41b3535ed608fe04129f26542b59ed99808b4f688aa32dcf55317a83
 
 build:
-  number: 2
-  noarch: python
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  number: 0
+  skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - jsonschema = jsonschema.cli:main
 
 requirements:
   host:
     - pip
-    - python >=3.6
-    - setuptools_scm
+    - python
+    - setuptools >=40.6.0
+    - setuptools_scm >=3.4
+    - toml
+    - wheel
   run:
+    - python
     - attrs >=17.4.0
-    # TODO: upstream, this is conditional to <3.8, but probably not worth the non-noarch build
-    - importlib_metadata
-    - pyrsistent >=0.14.0
-    # TODO: >3.2.0 sets this explicitly, but conda-forge no longer supports <3.6...
-    - python >=3.6
-    # TODO: >3.2.0 will no longer depend on/mention these
-    - six >=1.11.0
-    - setuptools
-    # technically still supported, but needed for noarch
-    # - functools32  # [py27]
+    - importlib_metadata  # [py<38]
+    - importlib_resources>=1.4.0  # [py<39]
+    - pyrsistent >=0.14.0,!=0.17.0,!=0.17.1,!=0.17.2
+    - typing_extensions  # [py<38]
 
 test:
-  requires:
-    - pip
   imports:
     - jsonschema
+  requires:
+    - pip
   commands:
     - python -m pip check
+    - jsonschema --version
     - jsonschema --help
+  downstreams:
+    - airflow
+    - cfn-lint
+    - cubes
+    - jupyterlab_server
+    - jupyter_telemetry
+    - nbformat
+    - spyder
 
 about:
   home: https://github.com/Julian/jsonschema
   license: MIT
+  license_family: MIT
   license_file: COPYING
   summary: An implementation of JSON Schema validation for Python
   description: |
     jsonschema is an implementation of JSON Schema for Python
-    (supporting 2.7+ including Python 3)
   doc_url: https://python-jsonschema.readthedocs.org
   doc_source_url: https://github.com/Julian/jsonschema/blob/v{{ version }}/docs/index.rst
   dev_url: https://github.com/Julian/jsonschema


### PR DESCRIPTION
Update jsonschema to 4.4.0

We don't split outputs now as conda-forge did https://github.com/conda-forge/jsonschema-feedstock/blob/main/recipe/meta.yaml because they are extra features, see https://github.com/python-jsonschema/jsonschema/blob/65f591e5152e37867cdd5db1baf6ae175229713e/setup.cfg#L38 but it can be discussed


Issues: https://github.com/python-jsonschema/jsonschema/issues
Changelog: https://github.com/python-jsonschema/jsonschema/blob/main/CHANGELOG.rst
License: https://github.com/python-jsonschema/jsonschema/blob/main/COPYING
Requirements:
 - https://github.com/python-jsonschema/jsonschema/blob/v4.4.0/pyproject.toml
 - https://github.com/python-jsonschema/jsonschema/blob/v4.4.0/setup.cfg