### PR TITLE
Update 4.16.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,20 +36,10 @@ test:
     - jsonschema
   requires:
     - pip
-    # For testing downstream package cubes
-    - setuptools
   commands:
     - python -m pip check
     - jsonschema --version
     - jsonschema --help
-  downstreams:
-    - airflow
-    - cfn-lint
-    - cubes
-    - jupyterlab_server
-    - jupyter_telemetry
-    - nbformat
-    - spyder
 
 about:
   home: https://github.com/Julian/jsonschema

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - wheel
     - hatchling
     - hatch-vcs
+    - pkgutil-resolve-name
   run:
     - python
     - attrs >=17.4.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.14.0" %}
+{% set version = "4.16.0" %}
 
 package:
   name: jsonschema
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/j/jsonschema/jsonschema-{{ version }}.tar.gz
-  sha256: 15062f4cc6f591400cd528d2c355f2cfa6a57e44c820dc783aee5e23d36a831f
+  sha256: 165059f076eff6971bae5b742fc029a7b4ef3f9bcf04c14e4776a7605de14b23
 
 build:
   number: 0
@@ -18,15 +18,15 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=3.7
     - pip
     - wheel
     - hatchling
     - hatch-vcs
   run:
-    - python
+    - python >=3.7
     - attrs >=17.4.0
-    - pyrsistent >=0.14.0,!=0.17.0,!=0.17.1,!=0.17.2
+    - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
     - importlib_metadata  # [py<38]
     - typing_extensions  # [py<38]
     - importlib_resources >=1.4.0  # [py<39]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - toml
     - wheel
     - hatchling
+    - hatch-vcs
   run:
     - python >=3.7
     - attrs >=17.4.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,9 @@ build:
 
 requirements:
   host:
-    - python >=3.7
+    - python
   run:
-    - python >=3.7
+    - python
 
 outputs:
   - name: jsonschema
@@ -25,7 +25,7 @@ outputs:
         - jsonschema = jsonschema.cli:main
     requirements:
       host:
-        - python >=3.7
+        - python
         - pip
         - setuptools-scm
       run:
@@ -35,7 +35,7 @@ outputs:
         - importlib_resources >=1.4.0
         - pkgutil-resolve-name >=1.3.10
         - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
-        - python >=3.7
+        - python
         - typing_extensions
     test:
       requires:
@@ -52,7 +52,7 @@ outputs:
     build:
     requirements:
       host:
-        - python >=3.7
+        - python
       run:
         - {{ pin_subpackage('jsonschema') }}
         - fqdn
@@ -75,7 +75,7 @@ outputs:
     build:
     requirements:
       host:
-        - python >=3.7
+        - python
       run:
         - {{ pin_subpackage('jsonschema') }}
         - fqdn
@@ -98,7 +98,7 @@ outputs:
     build:
     requirements:
       host:
-        - python >=3.7
+        - python
       run:
         - {{ pin_subpackage('jsonschema-with-format-nongpl') }}
         - {{ pin_subpackage('jsonschema-with-format') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.7
+    - python
     - setuptools
     - setuptools_scm >=3.4
     - toml
@@ -26,7 +26,7 @@ requirements:
     - hatchling
     - hatch-vcs
   run:
-    - python >=3.7
+    - python
     - attrs >=17.4.0
     - importlib_metadata  # [py<38]
     - importlib_resources>=1.4.0  # [py<39]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.9.1" %}
+{% set version = "4.14.0" %}
 
 package:
   name: jsonschema
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/j/jsonschema/jsonschema-{{ version }}.tar.gz
-  sha256: 408c4c8ed0dede3b268f7a441784f74206380b04f93eb2d537c7befb3df3099f
+  sha256: 15062f4cc6f591400cd528d2c355f2cfa6a57e44c820dc783aee5e23d36a831f
 
 build:
   number: 0
@@ -17,23 +17,19 @@ build:
 
 requirements:
   host:
-    - pip
     - python
-    - setuptools
-    - setuptools_scm >=3.4
-    - toml
+    - pip
     - wheel
     - hatchling
     - hatch-vcs
-    - pkgutil-resolve-name
   run:
     - python
     - attrs >=17.4.0
+    - pyrsistent >=0.14.0,!=0.17.0,!=0.17.1,!=0.17.2
     - importlib_metadata  # [py<38]
-    - importlib_resources>=1.4.0  # [py<39]
-    - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
     - typing_extensions  # [py<38]
-
+    - importlib_resources >=1.4.0  # [py<39]
+    - pkgutil-resolve-name >=1.3.10  # [py<39]
 test:
   imports:
     - jsonschema
@@ -46,7 +42,7 @@ test:
 
 
 about:
-  home: https://github.com/Julian/jsonschema
+  home:  https://github.com/python-jsonschema/jsonschema
   license: MIT
   license_family: MIT
   license_file: COPYING

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - hatchling
     - hatch-vcs
   run:
-    - python
+    - python >=3.7
     - attrs >=17.4.0
     - pyrsistent >=0.14.0,!=0.17.0,!=0.17.1,!=0.17.2
     - importlib_metadata  # [py<38]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ build:
   number: 0
   skip: True  # [py<37]
   # script: {{ PYTHON }} -m pip install . --no-deps -vv
-  script: hatch build
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - jsonschema = jsonschema.cli:main
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,130 +1,62 @@
 {% set version = "4.16.0" %}
 
 package:
-  name: jsonschema-meta
+  name: jsonschema
   version: {{ version }}
 
 source:
   url: https://pypi.io/packages/source/j/jsonschema/jsonschema-{{ version }}.tar.gz
   sha256: 165059f076eff6971bae5b742fc029a7b4ef3f9bcf04c14e4776a7605de14b23
-
+  patches:
+    - patches/001-remove-fancy-pypi-readme.patch
 build:
   number: 0
+  skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps
+  entry_points:
+    - jsonschema = jsonschema.cli:main
 
 requirements:
+  build:
+    - patch                # [unix]
+    - m2-patch             # [win]
+
   host:
     - python
+    - pip
+    - wheel
+    - hatchling
+    - hatch-vcs
   run:
     - python
+    - attrs >=17.4.0
+    - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+    - importlib_metadata  # [py<38]
+    - typing_extensions  # [py<38]
+    - importlib_resources >=1.4.0  # [py<39]
+    - pkgutil-resolve-name >=1.3.10  # [py<39]
 
-outputs:
-  - name: jsonschema
-    build:
-      script: {{ PYTHON }} -m pip install . --no-deps -vv
-      entry_points:
-        - jsonschema = jsonschema.cli:main
-    requirements:
-      host:
-        - python
-        - pip
-        - setuptools-scm
-      run:
-        - attrs >=17.4.0
-        # TODO: upstream, importlib-* are conditional to <3.8/9, but probably not worth the non-noarch builds
-        - importlib-metadata
-        - importlib_resources >=1.4.0
-        - pkgutil-resolve-name >=1.3.10
-        - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
-        - python
-        - typing_extensions
-    test:
-      requires:
-        - pip
-      imports:
-        - jsonschema
-      commands:
-        - pip check
-        - jsonschema --version
-        - jsonschema --help
-        - jsonschema --version | grep {{ version.replace(".", "\.") }}  # [unix]
+test:
+  imports:
+    - jsonschema
+  requires:
+    - pip
+  commands:
+    - pip check
+    - jsonschema --version
+    - jsonschema --help
 
-  - name: jsonschema-with-format
-    build:
-    requirements:
-      host:
-        - python
-      run:
-        - {{ pin_subpackage('jsonschema') }}
-        - fqdn
-        - idna
-        - isoduration
-        - jsonpointer >1.13
-        - rfc3339-validator
-        - rfc3987
-        - uri-template
-        - webcolors >=1.11
-    test:
-      requires:
-        - pip
-      imports:
-        - jsonschema
-      commands:
-        - pip check
-
-  - name: jsonschema-with-format-nongpl
-    build:
-    requirements:
-      host:
-        - python
-      run:
-        - {{ pin_subpackage('jsonschema') }}
-        - fqdn
-        - idna
-        - isoduration
-        - jsonpointer >1.13
-        - rfc3339-validator
-        - rfc3986-validator >0.1.0
-        - uri-template
-        - webcolors >=1.11
-    test:
-      requires:
-        - pip
-      imports:
-        - jsonschema
-      commands:
-        - pip check
-
-  - name: jsonschema-with-all
-    build:
-    requirements:
-      host:
-        - python
-      run:
-        - {{ pin_subpackage('jsonschema-with-format-nongpl') }}
-        - {{ pin_subpackage('jsonschema-with-format') }}
-    test:
-      files:
-        - start_test.py
-      source_files:
-        - json
-      requires:
-        - pip
-        - pytest-cov
-        - flask
-      imports:
-        - jsonschema
-      commands:
-        - pip check
-        # additional pytest args are set in start_test.py
-        - python start_test.py --cov-fail-under=97
 
 about:
-  home: https://github.com/python-jsonschema/jsonschema
+  home:  https://github.com/python-jsonschema/jsonschema
   license: MIT
+  license_family: MIT
   license_file: COPYING
   summary: An implementation of JSON Schema validation for Python
+  description: |
+    jsonschema is an implementation of JSON Schema for Python
   doc_url: https://python-jsonschema.readthedocs.org
-  doc_source_url: https://github.com/python-jsonschema/jsonschema/blob/v{{ version }}/docs/index.rst
+  doc_source_url: https://github.com/python-jsonschema/jsonschema/blob/v4.9.1/docs/index.rst
   dev_url: https://github.com/python-jsonschema/jsonschema
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - setuptools_scm >=3.4
     - toml
     - wheel
+    - hatchling
   run:
     - python >=3.7
     - attrs >=17.4.0
@@ -39,7 +40,7 @@ test:
   commands:
     - pip check
     - jsonschema --version
-    - jsonschema --help 
+    - jsonschema --help
 
 about:
   home: https://github.com/Julian/jsonschema

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,19 +12,19 @@ build:
   number: 0
   skip: True  # [py<37]
   # script: {{ PYTHON }} -m pip install . --no-deps -vv
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: hatch build
   entry_points:
     - jsonschema = jsonschema.cli:main
 
 requirements:
   host:
-    - python >=3.7
+    - python
     - pip
     - wheel
     - hatchling
     - hatch-vcs
   run:
-    - python >=3.7
+    - python
     - attrs >=17.4.0
     - pyrsistent >=0.14.0,!=0.17.0,!=0.17.1,!=0.17.2
     - importlib_metadata  # [py<38]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ test:
   commands:
     - pip check
     - jsonschema --version
-    - jsonschema --help
+    - jsonschema --help 
 
 about:
   home: https://github.com/Julian/jsonschema

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,6 @@ requirements:
 outputs:
   - name: jsonschema
     build:
-      noarch: python
       script: {{ PYTHON }} -m pip install . --no-deps -vv
       entry_points:
         - jsonschema = jsonschema.cli:main
@@ -51,7 +50,6 @@ outputs:
 
   - name: jsonschema-with-format
     build:
-      noarch: python
     requirements:
       host:
         - python >=3.7
@@ -75,7 +73,6 @@ outputs:
 
   - name: jsonschema-with-format-nongpl
     build:
-      noarch: python
     requirements:
       host:
         - python >=3.7
@@ -99,7 +96,6 @@ outputs:
 
   - name: jsonschema-with-all
     build:
-      noarch: python
     requirements:
       host:
         - python >=3.7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=3.7
     - pip
     - wheel
     - hatchling

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.2.0" %}
+{% set version = "4.4.0" %}
 
 package:
   name: jsonschema
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/j/jsonschema/jsonschema-{{ version }}.tar.gz
-  sha256: c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a
+  sha256: 636694eb41b3535ed608fe04129f26542b59ed99808b4f688aa32dcf55317a83
 
 build:
   number: 2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,7 @@ about:
   description: |
     jsonschema is an implementation of JSON Schema for Python
   doc_url: https://python-jsonschema.readthedocs.org
-  doc_source_url: https://github.com/python-jsonschema/jsonschema/blob/v4.9.1/docs/index.rst
+  doc_source_url: https://github.com/python-jsonschema/jsonschema/tree/main/docs
   dev_url: https://github.com/python-jsonschema/jsonschema
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,8 @@ test:
     - jsonschema
   requires:
     - pip
+    # For testing downstream package cubes
+    - setuptools
   commands:
     - python -m pip check
     - jsonschema --version

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "4.16.0" %}
 
 package:
-  name: jsonschema
+  name: jsonschema-meta
   version: {{ version }}
 
 source:
@@ -10,49 +10,125 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<37]
-  # script: {{ PYTHON }} -m pip install . --no-deps -vv
-  script: hatch build
-  entry_points:
-    - jsonschema = jsonschema.cli:main
 
 requirements:
   host:
     - python >=3.7
-    - pip
-    - wheel
-    - hatchling
-    - hatch-vcs
   run:
     - python >=3.7
-    - attrs >=17.4.0
-    - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
-    - importlib_metadata  # [py<38]
-    - typing_extensions  # [py<38]
-    - importlib_resources >=1.4.0  # [py<39]
-    - pkgutil-resolve-name >=1.3.10  # [py<39]
 
-test:
-  imports:
-    - jsonschema
-  requires:
-    - pip
-  commands:
-    - pip check
-    - jsonschema --version
-    - jsonschema --help
+outputs:
+  - name: jsonschema
+    build:
+      noarch: python
+      script: {{ PYTHON }} -m pip install . --no-deps -vv
+      entry_points:
+        - jsonschema = jsonschema.cli:main
+    requirements:
+      host:
+        - python >=3.7
+        - pip
+        - setuptools-scm
+      run:
+        - attrs >=17.4.0
+        # TODO: upstream, importlib-* are conditional to <3.8/9, but probably not worth the non-noarch builds
+        - importlib-metadata
+        - importlib_resources >=1.4.0
+        - pkgutil-resolve-name >=1.3.10
+        - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
+        - python >=3.7
+        - typing_extensions
+    test:
+      requires:
+        - pip
+      imports:
+        - jsonschema
+      commands:
+        - pip check
+        - jsonschema --version
+        - jsonschema --help
+        - jsonschema --version | grep {{ version.replace(".", "\.") }}  # [unix]
 
+  - name: jsonschema-with-format
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python >=3.7
+      run:
+        - {{ pin_subpackage('jsonschema') }}
+        - fqdn
+        - idna
+        - isoduration
+        - jsonpointer >1.13
+        - rfc3339-validator
+        - rfc3987
+        - uri-template
+        - webcolors >=1.11
+    test:
+      requires:
+        - pip
+      imports:
+        - jsonschema
+      commands:
+        - pip check
+
+  - name: jsonschema-with-format-nongpl
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python >=3.7
+      run:
+        - {{ pin_subpackage('jsonschema') }}
+        - fqdn
+        - idna
+        - isoduration
+        - jsonpointer >1.13
+        - rfc3339-validator
+        - rfc3986-validator >0.1.0
+        - uri-template
+        - webcolors >=1.11
+    test:
+      requires:
+        - pip
+      imports:
+        - jsonschema
+      commands:
+        - pip check
+
+  - name: jsonschema-with-all
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python >=3.7
+      run:
+        - {{ pin_subpackage('jsonschema-with-format-nongpl') }}
+        - {{ pin_subpackage('jsonschema-with-format') }}
+    test:
+      files:
+        - start_test.py
+      source_files:
+        - json
+      requires:
+        - pip
+        - pytest-cov
+        - flask
+      imports:
+        - jsonschema
+      commands:
+        - pip check
+        # additional pytest args are set in start_test.py
+        - python start_test.py --cov-fail-under=97
 
 about:
-  home:  https://github.com/python-jsonschema/jsonschema
+  home: https://github.com/python-jsonschema/jsonschema
   license: MIT
-  license_family: MIT
   license_file: COPYING
   summary: An implementation of JSON Schema validation for Python
-  description: |
-    jsonschema is an implementation of JSON Schema for Python
   doc_url: https://python-jsonschema.readthedocs.org
-  doc_source_url: https://github.com/python-jsonschema/jsonschema/blob/v4.9.1/docs/index.rst
+  doc_source_url: https://github.com/python-jsonschema/jsonschema/blob/v{{ version }}/docs/index.rst
   dev_url: https://github.com/python-jsonschema/jsonschema
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.4.0" %}
+{% set version = "4.9.1" %}
 
 package:
   name: jsonschema
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/j/jsonschema/jsonschema-{{ version }}.tar.gz
-  sha256: 636694eb41b3535ed608fe04129f26542b59ed99808b4f688aa32dcf55317a83
+  sha256: 408c4c8ed0dede3b268f7a441784f74206380b04f93eb2d537c7befb3df3099f
 
 build:
   number: 0
@@ -18,17 +18,17 @@ build:
 requirements:
   host:
     - pip
-    - python
-    - setuptools >=40.6.0
+    - python >=3.7
+    - setuptools
     - setuptools_scm >=3.4
     - toml
     - wheel
   run:
-    - python
+    - python >=3.7
     - attrs >=17.4.0
     - importlib_metadata  # [py<38]
     - importlib_resources>=1.4.0  # [py<39]
-    - pyrsistent >=0.14.0,!=0.17.0,!=0.17.1,!=0.17.2
+    - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
     - typing_extensions  # [py<38]
 
 test:
@@ -37,7 +37,7 @@ test:
   requires:
     - pip
   commands:
-    - python -m pip check
+    - pip check
     - jsonschema --version
     - jsonschema --help
 
@@ -50,10 +50,11 @@ about:
   description: |
     jsonschema is an implementation of JSON Schema for Python
   doc_url: https://python-jsonschema.readthedocs.org
-  doc_source_url: https://github.com/Julian/jsonschema/blob/v{{ version }}/docs/index.rst
-  dev_url: https://github.com/Julian/jsonschema
+  doc_source_url: https://github.com/python-jsonschema/jsonschema/blob/v4.9.1/docs/index.rst
+  dev_url: https://github.com/python-jsonschema/jsonschema
 
 extra:
+  feedstock-name: jsonschema
   recipe-maintainers:
     - minrk
     - ocefpaf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,8 @@ source:
 build:
   number: 0
   skip: True  # [py<37]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  # script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: hatch build
   entry_points:
     - jsonschema = jsonschema.cli:main
 
@@ -30,6 +31,7 @@ requirements:
     - typing_extensions  # [py<38]
     - importlib_resources >=1.4.0  # [py<39]
     - pkgutil-resolve-name >=1.3.10  # [py<39]
+
 test:
   imports:
     - jsonschema

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,47 +9,54 @@ source:
   sha256: 636694eb41b3535ed608fe04129f26542b59ed99808b4f688aa32dcf55317a83
 
 build:
-  number: 2
-  noarch: python
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  number: 0
+  skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - jsonschema = jsonschema.cli:main
 
 requirements:
   host:
     - pip
-    - python >=3.6
-    - setuptools_scm
+    - python
+    - setuptools >=40.6.0
+    - setuptools_scm >=3.4
+    - toml
+    - wheel
   run:
+    - python
     - attrs >=17.4.0
-    # TODO: upstream, this is conditional to <3.8, but probably not worth the non-noarch build
-    - importlib_metadata
-    - pyrsistent >=0.14.0
-    # TODO: >3.2.0 sets this explicitly, but conda-forge no longer supports <3.6...
-    - python >=3.6
-    # TODO: >3.2.0 will no longer depend on/mention these
-    - six >=1.11.0
-    - setuptools
-    # technically still supported, but needed for noarch
-    # - functools32  # [py27]
+    - importlib_metadata  # [py<38]
+    - importlib_resources>=1.4.0  # [py<39]
+    - pyrsistent >=0.14.0,!=0.17.0,!=0.17.1,!=0.17.2
+    - typing_extensions  # [py<38]
 
 test:
-  requires:
-    - pip
   imports:
     - jsonschema
+  requires:
+    - pip
   commands:
     - python -m pip check
+    - jsonschema --version
     - jsonschema --help
+  downstreams:
+    - airflow
+    - cfn-lint
+    - cubes
+    - jupyterlab_server
+    - jupyter_telemetry
+    - nbformat
+    - spyder
 
 about:
   home: https://github.com/Julian/jsonschema
   license: MIT
+  license_family: MIT
   license_file: COPYING
   summary: An implementation of JSON Schema validation for Python
   description: |
     jsonschema is an implementation of JSON Schema for Python
-    (supporting 2.7+ including Python 3)
   doc_url: https://python-jsonschema.readthedocs.org
   doc_source_url: https://github.com/Julian/jsonschema/blob/v{{ version }}/docs/index.rst
   dev_url: https://github.com/Julian/jsonschema

--- a/recipe/patches/001-remove-fancy-pypi-readme.patch
+++ b/recipe/patches/001-remove-fancy-pypi-readme.patch
@@ -1,0 +1,42 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index f5fe8db..7ae8318 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["hatchling", "hatch-vcs", "hatch-fancy-pypi-readme"]
++requires = ["hatchling", "hatch-vcs"]
+ build-backend = "hatchling.build"
+ 
+ [tool.hatch.version]
+@@ -76,30 +76,6 @@ Tidelift = "https://tidelift.com/subscription/pkg/pypi-jsonschema?utm_source=pyp
+ Changelog = "https://github.com/python-jsonschema/jsonschema/blob/main/CHANGELOG.rst"
+ Source = "https://github.com/python-jsonschema/jsonschema"
+ 
+-[tool.hatch.metadata.hooks.fancy-pypi-readme]
+-content-type = "text/x-rst"
+-
+-[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+-path = "README.rst"
+-end-before = ".. start cut from PyPI"
+-
+-[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+-path = "README.rst"
+-start-after = ".. end cut from PyPI\n\n\n"
+-
+-[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+-text = """
+-
+-
+-Release Information
+--------------------
+-
+-"""
+-
+-[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+-path = "CHANGELOG.rst"
+-pattern = "(^v.+?)\nv"
+-
+ [tool.isort]
+ from_first = true
+ include_trailing_comma = true


### PR DESCRIPTION
# `jsonschema` version bump to `4.16.0`
- updated sha256
- replace `setuptools` with `hatchling`
- updated dependencies and pinnings
- updated about section
- added patch to ignore dependency `fancy-pypi-readme`