### PR TITLE
v4.23.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.19.2" %}
+{% set version = "4.23.0" %}
 
 package:
   name: jsonschema
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/j/jsonschema/jsonschema-{{ version }}.tar.gz
-  sha256: c9ff4d7447eed9592c23a12ccee508baf0dd0d59650615e847feb6cdca74f392
+  sha256: d71497fef26351a33265337fa77ffeb82423f3ea21283cd9467bb03999266bc4
   patches:
     - patches/001-remove-fancy-pypi-readme.patch
 build:


### PR DESCRIPTION
jsonscheme v.4.23.0

**Destination channel:**  defaults

### Links

- [PKG-5308](https://anaconda.atlassian.net/browse/PKG-5308?atlOrigin=eyJpIjoiODE3NGZiODBkOWJlNGU5ZTg2OWRkMGY2ZTkzMTI3ZjgiLCJwIjoiaiJ9) 
- [Upstream repository](https://github.com/python-jsonschema/jsonschema/tree/v4.23.0)
- [Upstream changelog/diff](https://github.com/python-jsonschema/jsonschema/releases/tag/v4.23.0)
- [pyproject.toml](https://github.com/python-jsonschema/jsonschema/blob/v4.23.0/pyproject.toml)

### Explanation of changes:

- Bump version and update SHA


[PKG-5308]: https://anaconda.atlassian.net/browse/PKG-5308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ