### PR TITLE
Jsonschema 4.20.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_check: False

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.25.0" %}
+{% set version = "4.20.0" %}
 {% set name = "jsonschema" %}
 package:
   name: {{ name|lower }}
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e63acf5c11762c0e6672ffb61482bdf57f0876684d8d249c0fe2d730d48bc55f
+  sha256: 4f614fd46d8d61258610998997743ec5492a648b33cf478c1ddc23ed4598a5fa
 
 build:
   number: 0
@@ -23,9 +23,11 @@ requirements:
     - hatch-vcs
     - hatch-fancy-pypi-readme
   run:
-    - python
     - attrs >=22.2.0
+    - importlib_resources >=1.4.0  # [py<39]
     - jsonschema-specifications >=2023.03.6
+    - pkgutil-resolve-name >=1.3.10  # [py<39]
+    - python >=3.8
     - referencing >=0.28.4
     - rpds-py >=0.7.1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<39]
+  skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -v
   entry_points:
     - jsonschema = jsonschema.cli:main
@@ -27,7 +27,7 @@ requirements:
     - importlib_resources >=1.4.0  # [py<39]
     - jsonschema-specifications >=2023.03.6
     - pkgutil-resolve-name >=1.3.10  # [py<39]
-    - python >=3.8
+    - python
     - referencing >=0.28.4
     - rpds-py >=0.7.1
 


### PR DESCRIPTION
## ☆ jsonschema 4.20.0 ☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-8737) 
[Upstream](https://github.com/python-jsonschema/jsonschema)

### Changes
* Downgrade to version 4.20.0 to fix CVE-2025-53365 in mcp
