### PR TITLE
jsonschema 4.25.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.25.0" %}
+{% set version = "4.25.1" %}
 {% set name = "jsonschema" %}
 package:
   name: {{ name|lower }}
@@ -6,14 +6,14 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e63acf5c11762c0e6672ffb61482bdf57f0876684d8d249c0fe2d730d48bc55f
+  sha256: e4a9655ce0da0c0b67a085847e00a3a51449e1157f4f75e9fb5aa545e122eb85
 
 build:
-  number: 1
-  skip: True  # [py<39]
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -v
   entry_points:
     - jsonschema = jsonschema.cli:main
+  skip: true  # [py<39]
 
 requirements:
   host:


### PR DESCRIPTION
jsonschema 4.25.1 

**Destination channel:** Defaults

### Links

- [PKG-11571]
- dev_url:        https://github.com/python-jsonschema/jsonschema/tree/v4.25.1
- conda_forge:    https://github.com/conda-forge/jsonschema-feedstock
- pypi:           https://pypi.org/project/jsonschema/4.25.1
- pypi inspector: https://inspector.pypi.io/project/jsonschema/4.25.1

### Explanation of changes:

- new version number


[PKG-11571]: https://anaconda.atlassian.net/browse/PKG-11571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ